### PR TITLE
Add order confirmation button for gestor role

### DIFF
--- a/src/app/pages/private/pedidos/pedidos.component.html
+++ b/src/app/pages/private/pedidos/pedidos.component.html
@@ -77,6 +77,13 @@
                 <td class="px-6 py-3">{{ p.empleado }}</td>
                 <td class="px-6 py-3 text-right">
                   <div class="flex justify-end gap-2">
+                    <button
+                      *ngIf="p.estado === 0 && (role$ | async) === 'gestor'"
+                      (click)="confirmar(p.id); $event.stopPropagation()"
+                      class="inline-flex items-center gap-1 rounded-full bg-amber-50 px-3 py-1 text-xs font-medium text-amber-600 hover:bg-amber-100"
+                    >
+                      <i class="fa-solid fa-check"></i> Confirmar
+                    </button>
                     <a
                       (click)="$event.stopPropagation()"
                       [routerLink]="['/pedidos/detalle', p.id]"
@@ -123,6 +130,13 @@
             </div>
             <p class="mt-2 text-xs text-gray-500">Repartidor: {{ p.empleado ?? '—' }}</p>
             <div class="mt-4 flex gap-2">
+              <button
+                *ngIf="p.estado === 0 && (role$ | async) === 'gestor'"
+                (click)="confirmar(p.id); $event.stopPropagation()"
+                class="flex-1 text-center inline-flex items-center justify-center gap-1 rounded-full bg-amber-50 px-3 py-2 text-xs font-medium text-amber-600 hover:bg-amber-100"
+              >
+                <i class="fa-solid fa-check"></i> Confirmar
+              </button>
               <a
                 (click)="$event.stopPropagation()"
                 [routerLink]="['/pedidos/detalle', p.id]"

--- a/src/app/pages/private/pedidos/pedidos.component.ts
+++ b/src/app/pages/private/pedidos/pedidos.component.ts
@@ -11,6 +11,7 @@ import { PedidosService } from '../../../core/services/pedido.service';
 import { ClientesService } from '../../../core/services/cliente.service';
 import { DireccionesService } from '../../../core/services/direcciones.service';
 import { EmpleadosService } from '../../../core/services/empleados.service';
+import { LoginService } from '../../../core/services/login.service';
 import { PedidoEstadoPipe } from '../../../shared/pedido-estado.pipe';
 import Swal from 'sweetalert2';
 
@@ -46,10 +47,12 @@ export class PedidosComponent implements OnInit {
   private clientesSvc = inject(ClientesService);
   private dirSvc = inject(DireccionesService);
   private empSvc = inject(EmpleadosService);
+  private loginSvc = inject(LoginService);
 
   pedidos$: Observable<PedidoVM[]> = of([]);
   errorMsg = '';
   filtro = -1;
+  role$ = this.loginSvc.role$;
   
    constructor(private router: Router) {}
 
@@ -130,6 +133,22 @@ export class PedidosComponent implements OnInit {
           return of([]);
         })
       ).subscribe(vms => this.pedidos$ = of(vms));
+    });
+  }
+
+  confirmar(id: number): void {
+    Swal.fire({
+      title: `¿Confirmar pedido #${id}?`,
+      icon: 'question',
+      showCancelButton: true,
+      confirmButtonText: 'Sí, confirmar',
+      cancelButtonText: 'Cancelar',
+    }).then(result => {
+      if (!result.isConfirmed) return;
+      this.pedidosSvc.confirmar(id).subscribe({
+        next: () => { Swal.fire('Confirmado', '', 'success'); this.load(); },
+        error: err => Swal.fire('Error', err.message, 'error'),
+      });
     });
   }
 


### PR DESCRIPTION
## Summary
- allow Gestor users to confirm orders from the orders list
- show Confirmar button when an order is in "Creado" state

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68481a3358cc832c89a266c06da80f63